### PR TITLE
External menu links not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function buildLink(link) {
       {link.title}
     </Link>)
   } else {
-    return ( <a href={link.link.uri_alias} className={'external'}>
+    return ( <a href={link.link.uri} className={'external'}>
       {link.title}
     </a>)
   }


### PR DESCRIPTION
Because external menu links have no `uri_alias` property the href is not generated when running Gatsby. This PR fixes this by using the `link.uri` property instead.